### PR TITLE
 Added a Missing HTML id for the comments section

### DIFF
--- a/news/72.bugfix.rst
+++ b/news/72.bugfix.rst
@@ -1,0 +1,8 @@
+4.0.1 (2023-03-19)
+------------------
+
+Bug fixes:
+
+
+- Added a Missing HTML id for the comments section [Coder-aadarsh] (#72)
+//id attribute with the value "comments" to the div tag will make it possible to directly link to the comments section of a Plone document using the URL of the document followed by "#comments".

--- a/plone/app/discussion/browser/comments.pt
+++ b/plone/app/discussion/browser/comments.pt
@@ -43,7 +43,9 @@
                              colorclass python:lambda x: 'state-private' if x=='rejected' else ('state-internal' if x=='spam' else 'state-'+x);"
                     tal:attributes="class python:'comment level-{depth} {state}'.format(depth= depth, state=colorclass(review_state));
                                  id comment_id"
-                    tal:condition="python:canReview or review_state == 'published'">
+                    tal:condition="python:canReview or review_state == 'published'or has_replies"
+                    tal:attributes-missing="skip"
+                    id="comments">
 
                     <div class="d-flex flex-row align-items-center mb-3">
 


### PR DESCRIPTION
 Added a Missing HTML id for the comments section. A suggestive issue raised by @keul at [#72](https://github.com/plone/plone.app.discussion/issues/72#issue-96313609) 

To add a unique id to the comments section in Plone's comments template I have added an id attribute to the div tag that contains the comments. This will add the id attribute with the value "comments" to the div tag, which will make it possible to directly link to the comments section of a Plone document using the URL of the document followed by "#comments".
